### PR TITLE
Release v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Banana Split
 A SM64 and Rom Hack autosplitter for LiveSplit.
 
-Version 1.1.0.
+Version 1.1.1.
 
 # 1. Introduction
 Original concept and base work by [Bored Banana](https://twitch.tv/bored_banana).

--- a/script.asl
+++ b/script.asl
@@ -356,7 +356,7 @@ split {
   // check splitting on star grab conditions
   if (vars.numberInSplit >= 0) { // there is a number in the current split
     if (settings[vars.settings.SPLIT_ON_TOTAL_STARS] && !settings[vars.settings.ENABLE_STAGE_RTA_MODE]) { // splitting on total stars
-      if (current.stars != old.stars) {
+      if (current.stars != old.stars && current.time != 0) {
         addSplitCondition(current.stars >= vars.numberInSplit);
       }
     } else { // not splitting on total stars

--- a/script.asl
+++ b/script.asl
@@ -174,7 +174,7 @@ startup {
   // #region regexes
   vars.regexes = new ExpandoObject();
 
-  vars.regexes.REGEX_RESET = new System.Text.RegularExpressions.Regex(@"\breset\b");
+  vars.regexes.REGEX_RESET = new System.Text.RegularExpressions.Regex(@"(?i)\breset\b");
   // #endregion regexes
 
   vars.isSplittingOnLevelChange = false;


### PR DESCRIPTION
bugfixes:
 - Timer no longer splits when resetting due to invalid star counts during RAM load.
 - The 'reset' regex is no longer case sensitive.